### PR TITLE
Always let servers know if R2B is connecting

### DIFF
--- a/src/main/java/com/github/dirtpowered/releasetobeta/network/translator/moderntobeta/B_1_7/LoginStartTranslator.java
+++ b/src/main/java/com/github/dirtpowered/releasetobeta/network/translator/moderntobeta/B_1_7/LoginStartTranslator.java
@@ -47,7 +47,7 @@ public class LoginStartTranslator implements ModernToBeta<LoginStartPacket> {
         InetSocketAddress socketAddress = (InetSocketAddress) modernSession.getRemoteAddress();
 
         long address = flag ? serializeAddress(socketAddress.getAddress().getHostAddress()) : 0;
-        byte header = (byte) (flag ? -999 : 0);
+        byte header = (byte) (flag ? -999 : 1);
 
         betaSession.getPlayer().fillProfile(username, result -> {
             betaSession.sendPacket(new HandshakePacketData(username));


### PR DESCRIPTION
Send header byte 1 to notify the server that player is using R2B. Byte 25 is still required for IP Forwarding.